### PR TITLE
Update catalogue URL for UBMA

### DIFF
--- a/bibs/Mannheim_Uni.json
+++ b/bibs/Mannheim_Uni.json
@@ -8,7 +8,7 @@
     "city": "Mannheim",
     "country": "Deutschland",
     "data": {
-        "baseurl": "http://primo.bib.uni-mannheim.de/primo_library/libweb",
+        "baseurl": "https://primo.bib.uni-mannheim.de/",
         "db": "MAN_UB",
         "languages": [
             "de",


### PR DESCRIPTION
The url entry seems to be outdated (at least this is stated when opening the url in a browser). I'm not sure whether or not this is relevant for the app, but I'd like to provide the current url just in case.

Possible other values (since primo.bib.uni-mannheim.de is a redirect) are https://primo.bib.uni-mannheim.de/primo-explore/search?vid=MAN_UB and https://primo.bib.uni-mannheim.de/primo-explore/search?vid=MAN_UB&sortby=rank&lang=de_DE