### PR TITLE
Update baseurl for Bielefeld FH

### DIFF
--- a/bibs/Bielefeld_FH.json
+++ b/bibs/Bielefeld_FH.json
@@ -9,7 +9,7 @@
     "city": "Bielefeld",
     "country": "Deutschland",
     "data": {
-        "baseurl": "https://netbz05.fh-bielefeld.de/webOPACClient"
+        "baseurl": "https://bib5w.fh-bielefeld.de/webOPACClient"
     },
     "geo": [
         52.0302285,


### PR DESCRIPTION
As mentioned in opacapp/opacclient#538 the library data of Bielefeld FH is outdated. This pull request updates the baseurl.