### PR TITLE
Make the seven remaining information urls absolute

### DIFF
--- a/bibs/Bad Friedrichshall.json
+++ b/bibs/Bad Friedrichshall.json
@@ -28,7 +28,7 @@
         49.22756,
         9.21026
     ],
-    "information": "/../read-bad-friedrichshall/info.html",
+    "information": "https://web-opac.kivbf.de/read-bad-friedrichshall/info.html",
     "library_id": 1251,
     "state": "Baden-W\u00fcrttemberg",
     "title": "Stadtb\u00fccherei"

--- a/bibs/Boxberg.json
+++ b/bibs/Boxberg.json
@@ -28,7 +28,7 @@
         49.4822686,
         9.6395128
     ],
-    "information": "/../read-boxberg/info.html",
+    "information": "https://web-opac.kivbf.de/read-boxberg/info.html",
     "library_id": 1853,
     "state": "Baden-W\u00fcrttemberg",
     "title": "Mediothek"

--- a/bibs/Eppingen.json
+++ b/bibs/Eppingen.json
@@ -44,7 +44,7 @@
         49.13663,
         8.90808
     ],
-    "information": "/../read-eppingen/info.html",
+    "information": "https://web-opac.kivbf.de/read-eppingen/info.html",
     "library_id": 2671,
     "state": "Baden-W\u00fcrttemberg",
     "title": "Stadtb\u00fccherei"

--- a/bibs/Gaildorf.json
+++ b/bibs/Gaildorf.json
@@ -28,7 +28,7 @@
         49.00055,
         9.77059
     ],
-    "information": "/../read-gaildorf/info.html",
+    "information": "https://web-opac.kivbf.de/read-gaildorf/info.html",
     "library_id": 3088,
     "state": "Baden-W\u00fcrttemberg",
     "title": "Stadtb\u00fccherei"

--- a/bibs/HannMunden.json
+++ b/bibs/HannMunden.json
@@ -48,7 +48,7 @@
         51.41813,
         9.65436
     ],
-    "information": "/read/info.html",
+    "information": "http://www.buecherei.hann.muenden.de/read/info.html",
     "library_id": 3617,
     "state": "Niedersachsen",
     "title": "Stadtb\u00fccherei"

--- a/bibs/NeuUlm.json
+++ b/bibs/NeuUlm.json
@@ -53,7 +53,7 @@
         48.3940236,
         10.0034433
     ],
-    "information": "/../read/info.html",
+    "information": "https://webopac.neu-ulm.de/read/info.html",
     "library_id": 5723,
     "state": "Bayern",
     "title": "Stadtb\u00fccherei"

--- a/bibs/Stuhr.json
+++ b/bibs/Stuhr.json
@@ -57,7 +57,7 @@
         53.02438,
         8.72675
     ],
-    "information": "/read/info.html",
+    "information": "http://bibliothek.stuhr.de/read/info.html",
     "library_id": 7517,
     "state": "Niedersachsen",
     "title": "Bibliothek"


### PR DESCRIPTION
All libraries use absolute urls to point to the "information", except seven of them.
This pull request changes the remainen seven library configs from relative to absolute urls.