### PR TITLE
Update Stadtbücherei Augsburg

### DIFF
--- a/bibs/Augsburg.json
+++ b/bibs/Augsburg.json
@@ -6,11 +6,11 @@
     "_support_contract": false,
     "_version_required": 0,
     "account_supported": true,
-    "api": "sisis",
+    "api": "koha",
     "city": "Augsburg",
     "country": "Deutschland",
     "data": {
-        "baseurl": "https://opac-stadtbuecherei.augsburg.de/webOPACClient.stasis"
+        "baseurl": "https://sb-augsburg.lmscloud.net"
     },
     "geo": [
         48.3692816,

--- a/bibs/Augsburg.json
+++ b/bibs/Augsburg.json
@@ -12,14 +12,14 @@
     "data": {
         "baseurl": "https://sb-augsburg.lmscloud.net",
         "libopacplus": true,
-        "onleihe": "http://www.onleihe.de/augsburg/",
+        "onleihe": "https://www.onleihe.de/augsburg/",
         "onleihe_libraryId": "104"
     },
     "geo": [
         48.3692816,
         10.8951371
     ],
-    "information": "http://www.stadtbuecherei.augsburg.de/index.php?id=sb_standorte",
+    "information": "https://stadtbuecherei.augsburg.de/sb-standorte/standorte-und-oeffnungszeiten",
     "library_id": 8608,
     "state": "Bayern",
     "title": "Stadtb\u00fccherei"

--- a/bibs/Augsburg.json
+++ b/bibs/Augsburg.json
@@ -12,14 +12,14 @@
     "data": {
         "baseurl": "https://sb-augsburg.lmscloud.net",
         "libopacplus": true,
-        "onleihe": "http://www.onleihe.de/augsburg/",
+        "onleihe": "https://www.onleihe.de/augsburg/",
         "onleihe_libraryId": "104"
     },
     "geo": [
         48.3692816,
         10.8951371
     ],
-    "information": "http://www.stadtbuecherei.augsburg.de/index.php?id=sb_standorte",
+    "information": "https://www.stadtbuecherei.augsburg.de/index.php?id=sb_standorte",
     "library_id": 8608,
     "state": "Bayern",
     "title": "Stadtb\u00fccherei"

--- a/bibs/Augsburg.json
+++ b/bibs/Augsburg.json
@@ -12,14 +12,14 @@
     "data": {
         "baseurl": "https://sb-augsburg.lmscloud.net",
         "libopacplus": true,
-        "onleihe": "https://www.onleihe.de/augsburg/",
+        "onleihe": "http://www.onleihe.de/augsburg/",
         "onleihe_libraryId": "104"
     },
     "geo": [
         48.3692816,
         10.8951371
     ],
-    "information": "https://www.stadtbuecherei.augsburg.de/index.php?id=sb_standorte",
+    "information": "http://www.stadtbuecherei.augsburg.de/index.php?id=sb_standorte",
     "library_id": 8608,
     "state": "Bayern",
     "title": "Stadtb\u00fccherei"

--- a/bibs/Augsburg.json
+++ b/bibs/Augsburg.json
@@ -10,7 +10,10 @@
     "city": "Augsburg",
     "country": "Deutschland",
     "data": {
-        "baseurl": "https://sb-augsburg.lmscloud.net"
+        "baseurl": "https://sb-augsburg.lmscloud.net",
+        "libopacplus": true,
+        "onleihe": "http://www.onleihe.de/augsburg/",
+        "onleihe_libraryId": "104"
     },
     "geo": [
         48.3692816,


### PR DESCRIPTION
Stadtbücherei Augsburg switched their catalogue from webOPAC to LMSCloud. Also added Onleihe.