### PR TITLE
Stadtbibliothek Böblingen moved to Koha (lmscloud)

### DIFF
--- a/bibs/Boeblingen.json
+++ b/bibs/Boeblingen.json
@@ -6,53 +6,17 @@
     "_support_contract": false,
     "_version_required": 0,
     "account_supported": true,
-    "api": "biber1992",
+    "api": "koha",
     "city": "B\u00f6blingen",
     "country": "Deutschland",
     "data": {
-        "accounttable": {
-            "author": 8,
-            "barcode": 4,
-            "homebranch": -1,
-            "lendingbranch": -1,
-            "prolongurl": 4,
-            "returndate": 3,
-            "status": 9,
-            "title": 8
-        },
-        "baseurl": "https://boeblingen.bibdia-hosts.de",
-        "copiestable": {
-            "barcode": 2,
-            "branch": 0,
-            "location": -1,
-            "reservations": -1,
-            "returndate": -1,
-            "shelfmark": 1,
-            "status": 3
-        },
-        "mediatypes": {
-            "1": "BOOK",
-            "10": "MAP",
-            "11": "DVD",
-            "2": "MAGAZINE",
-            "26": "GAME_CONSOLE",
-            "3": "CD_SOFTWARE",
-            "30": "EBOOK",
-            "6": "CD",
-            "9": "BOARDGAME"
-        },
-        "opacdir": "opax",
-        "searchtable": [
-            2,
-            3,
-            4
-        ]
+        "baseurl": "https://sb-boeblingen.lmscloud.net",
     },
     "geo": [
         48.6836954,
         9.0148348
     ],
-    "information": "http://www.boeblingen.de/,Lde/start/FreizeitKultur/Stadtbibliothek.html",
+    "information": "https://bibliothek.boeblingen.de/start",
     "library_id": 32,
     "state": "Baden-W\u00fcrttemberg",
     "title": "Stadtbibliothek"


### PR DESCRIPTION
update to reflect recent move to the Koha library system