### PR TITLE
Use HTTPS for St. Matthäus Alfter

### DIFF
--- a/bibs/Alfter_StMatthaeus.json
+++ b/bibs/Alfter_StMatthaeus.json
@@ -16,7 +16,7 @@
             "returndate": 2,
             "title": 1
         },
-        "baseurl": "http://87.139.71.230/webopac",
+        "baseurl": "https://opac.buecherei-alfter.de/webopac",
         "copiestable": {
             "barcode": 0,
             "department": 2,
@@ -40,7 +40,7 @@
         50.7380202,
         7.0086792
     ],
-    "information": "http://www.buecherei-alfter.de/",
+    "information": "https://www.buecherei-alfter.de/",
     "library_id": 951,
     "state": "Nordrhein-Westfalen",
     "title": "\u00d6ffentliche Bibliothek St. Matth\u00e4us"


### PR DESCRIPTION
St. Matthäus Alfter supports HTTPS via the browser, so I assume that the App should be able to use this, too. The hostname resolves to the IP address that was used in the past. I don't see a possibility to update the hostname direclty in the app to test this.