### PR TITLE
Haltern am See - KöB Updates

### DIFF
--- a/bibs/Haltern_St_Joseph.json
+++ b/bibs/Haltern_St_Joseph.json
@@ -28,5 +28,5 @@
     "information": "https://webopac.bistum-muenster.de/sythen/index.asp",
     "library_id": 3579,
     "state": "Nordrhein-Westfalen",
-    "title": "Kath. \u00d6B St. Joseph"
+    "title": "Kath. \u00d6B St. Joseph Sythen" 
 }

--- a/bibs/Haltern_St_Lambertus.json
+++ b/bibs/Haltern_St_Lambertus.json
@@ -1,0 +1,32 @@
+{
+    "_active": true,
+    "_notice_text": "",
+    "_plus_required": false,
+    "_plus_store_url": null,
+    "_support_contract": false,
+    "_version_required": 0,
+    "account_supported": true,
+    "api": "bibliotheca",
+    "city": "Haltern am See",
+    "country": "Deutschland",
+    "data": {
+        "baseurl": "https://webopac.bistum-muenster.de/lippramsdorf",
+        "copiestable": {
+            "barcode": 0,
+            "branch": 4,
+            "department": 2,
+            "location": 1,
+            "reservations": -1,
+            "returndate": 5,
+            "status": 3
+        }
+    },
+    "geo": [
+        51.71393,
+        7.09786
+    ],
+    "information": "https://webopac.bistum-muenster.de/lippramsdorf/index.asp",
+    "library_id": 3579,
+    "state": "Nordrhein-Westfalen",
+    "title": "Kath. \u00d6B St. Lambertus Lippramsdorf" 
+}


### PR DESCRIPTION
Hier ist ein pull-Request für die katholischen öffentlichen Bibliotheken in Haltern am See mit verbesserten Informationen zu St. Joseph und der Neuaufnahme für St. Lambertus. Die Bibliotheken sind seit letztem Monat in einem Datenbank-Verbund.
Das JSON beider Bibliotheken habe ich gegen die libopac getestet. Die Suche im Bestand und Suche nach schon ausgeliehenen Medien hat funktioniert.
Nur für die library_id bei St. Lambertus Lippramsdorf wusste ich nicht, was ich dort eintragen soll. Es ist eine Kopie von St. Joseph Sythen aktuell.

Viele Grüße
Thomas