### PR TITLE
Fix HS Esslingen library with new startparams

### DIFF
--- a/bibs/Esslingen_HS.json
+++ b/bibs/Esslingen_HS.json
@@ -11,7 +11,7 @@
     "country": "Deutschland",
     "data": {
         "baseurl": "https://bsz.ibs-bw.de/aDISWeb/app",
-        "startparams": "service=direct/0/Home/$DirectLink&sp=S127.0.0.1:23072"
+        "startparams": "service=direct/0/Home/$DirectLink&sp=SOPAC07"
     },
     "geo": [
         48.7433425,


### PR DESCRIPTION
Right now this library does not work at all. The app only shows an error screen sating that the connection to the library server failed.
Using the url in the json returns an error from the library system: "Error: connect parameter format "sp=S<host>:<port>" not allowed, use symbolic name instead".
As I am a student at Hochschule Esslingen, I could issue a search and thereby get the correct parameter.
I modified the json file and could succesfully issue searches in the emulator and even login to the library.
As I do not have any media borrowed right now, I could not test this, but I cannot think of a reason, why this should't be possible.