### PR TITLE
Renaming of the university & domain change

### DIFF
--- a/bibs/Berlin_BHT.json
+++ b/bibs/Berlin_BHT.json
@@ -10,14 +10,14 @@
     "city": "Berlin",
     "country": "Deutschland",
     "data": {
-        "baseurl": "https://webopac.beuth-hochschule.de/webOPACClient.bhssis"
+        "baseurl": "https://webopac.bht-berlin.de/webOPACClient.bhssis"
     },
     "geo": [
         52.5451745,
         13.3515848
     ],
-    "information": "http://www.beuth-hochschule.de/782/",
+    "information": "https://www.bht-berlin.de/782/",
     "library_id": 8845,
     "state": "Berlin",
-    "title": "Beuth-Hochschule"
+    "title": "Berliner Hochschule für Technik (BHT)"
 }


### PR DESCRIPTION
This university was renamed in October 2021. Since then, all websites (incl. the library) are available under the new domain [bht-berlin.de](https://bht-berlin.de).

[https://doku.bht-berlin.de/misc/umbenennung](https://doku.bht-berlin.de/misc/umbenennung)

Due to filename consistency, the configuration file should also be renamed.