### PR TITLE
Switch of API for Brigitte-Reimann library in Hoyerswerda 

### DIFF
--- a/bibs/Hoyerswerda.json
+++ b/bibs/Hoyerswerda.json
@@ -10,7 +10,7 @@
     "city": "Hoyerswerda",
     "country": "Deutschland",
     "data": {
-        "baseurl": "https://sb-hoyerswerda.lmscloud.net/",
+        "baseurl": "https://sb-hoyerswerda.lmscloud.net",
     },
     "geo": [
         51.43637,

--- a/bibs/Hoyerswerda.json
+++ b/bibs/Hoyerswerda.json
@@ -16,7 +16,7 @@
         51.43637,
         14.25677
     ],
-    "information": "http://www.bibliothek-hy.de/",
+    "information": "https://bibliothek-hy.de/",
     "library_id": 8698,
     "state": "Sachsen",
     "title": "Brigitte-Reimann Stadtbibliothek"

--- a/bibs/Hoyerswerda.json
+++ b/bibs/Hoyerswerda.json
@@ -6,40 +6,11 @@
     "_support_contract": false,
     "_version_required": 0,
     "account_supported": true,
-    "api": "bibliotheca",
+    "api": "koha",
     "city": "Hoyerswerda",
     "country": "Deutschland",
     "data": {
-        "accounttable": {
-            "author": 1,
-            "prolongurl": 4,
-            "returndate": 3,
-            "title": 2
-        },
-        "baseurl": "http://85.183.149.21",
-        "copiestable": {
-            "barcode": 1,
-            "branch": 0,
-            "location": 2,
-            "returndate": 5,
-            "status": 4
-        },
-        "mediatypes": {
-            "Icon_eAudio.gif": "MP3",
-            "Icon_eBook.gif": "EBOOK",
-            "Icon_ePaper.gif": "EDOC",
-            "Icon_eVideo.gif": "EVIDEO",
-            "Spiele.gif": "BOARDGAME",
-            "dvdgms.gif": "GAME_CONSOLE",
-            "eText2.gif": "EDOC",
-            "film.gif": "BLURAY",
-            "mCasetteS.gif": "AUDIO_CASSETTE"
-        },
-        "reservationtable": {
-            "author": 0,
-            "cancelurl": 2,
-            "title": 1
-        }
+        "baseurl": "https://sb-hoyerswerda.lmscloud.net/",
     },
     "geo": [
         51.43637,


### PR DESCRIPTION
The host for the bibliotheca API doesn't seem to exist anymore and the library has a lmscloud.net page