### PR TITLE
Update university library of Osnabrück

### DIFF
--- a/bibs/Osnabrueck_HS.json
+++ b/bibs/Osnabrueck_HS.json
@@ -10,8 +10,10 @@
     "city": "Osnabr\u00fcck",
     "country": "Deutschland",
     "data": {
-        "baseurl": "https://opac.ub.uni-osnabrueck.de",
-        "db": "2"
+        "baseurl": "https://opac.lbs-osnabrueck.gbv.de",
+        "db": "2",
+        "account_system": "lbs",
+        "lbs_url": "https://lbsosb.gbv.de"
     },
     "geo": [
         52.2729596,

--- a/bibs/Osnabrueck_Uni.json
+++ b/bibs/Osnabrueck_Uni.json
@@ -11,7 +11,9 @@
     "country": "Deutschland",
     "data": {
         "baseurl": "https://opac.ub.uni-osnabrueck.de",
-        "db": "1"
+        "db": "1",
+        "account_system": "lbs",
+        "lbs_url": "https://opac.lbs-osnabrueck.gbv.de"
     },
     "geo": [
         52.2729596,


### PR DESCRIPTION
Since a recent software update, the Osnabrück university's and university of applied sciences' libraries use Pica LBS instead of Pica, so the Opac App could not access account data for these libraries.
It is possible that a similar change will be necessary for the other libraries of the Common Library Network (gbv.de), but I currently lack the resources to test this.